### PR TITLE
Update bridging

### DIFF
--- a/lib/ClangImporter/bridging
+++ b/lib/ClangImporter/bridging
@@ -140,6 +140,19 @@
 #define SWIFT_MUTATING \
   __attribute__((swift_attr("mutating")))
 
+/// Specifies that a specific c++ type such class or struct should be imported as type marked 
+/// as `@unchecked Sendable` type in swift. If this annotation is used, the type is therefore allowed to
+/// use safely across async contexts.
+///
+/// For example 
+/// ```
+///   class SWIFT_UNCHECKED_SENDABLE CustomUserType
+///   { ... } 
+/// ``` 
+/// Will be imported as `struct CustomUserType: @unchecked Sendable`
+#define SWIFT_UNCHECKED_SENDABLE \
+  __attribute__((swift_attr("@Sendable)))
+
 #else  // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 
 // Empty defines for compilers that don't support `attribute(swift_attr)`.
@@ -151,7 +164,8 @@
 #define SWIFT_NAME(_name)
 #define SWIFT_CONFORMS_TO_PROTOCOL(_moduleName_protocolName)
 #define SWIFT_COMPUTED_PROPERTY
-#define SWIFT_MUTATING
+#define SWIFT_MUTATING 
+#define SWIFT_UNCHECKED_SENDABLE
 
 #endif // #if _CXX_INTEROP_HAS_ATTRIBUTE(swift_attr)
 


### PR DESCRIPTION
Import custom c++ types as unchecked sendable types

This allow custom c++ types to be imported as sendable types if the developer manually checks and ensure that such type when used in async context would be free from all data race bugs